### PR TITLE
Handle case where inputs are FASTQ

### DIFF
--- a/laims/build38realignmentdirectory.py
+++ b/laims/build38realignmentdirectory.py
@@ -42,9 +42,11 @@ class InputJson(object):
     def seqids(self):
         return [ utils.id_for_readgroup_string(x[1]) for x in self.json_data['sequence']['analysis']['data']]
 
-    def bams(self):
+    def readgroups(self):
+        # Note that as of 4/25 we are seeing json with two fastqs instead of a uBAM
+        # In addition, we occasionally see json with no readgroup information at all
         data_list = self.json_data['sequence']['analysis']['data']
-        if data_list[0][1].startswith('@RG'):
+        if len(data_list[0]) in [2, 3] and data_list[0][-1].startswith('@RG'):
             return [x[0] for x in data_list]
         else:
             return data_list[0]

--- a/laims/directoryvalidation.py
+++ b/laims/directoryvalidation.py
@@ -62,7 +62,7 @@ class B38DirectoryValidator(object):
         cram = CramFile(self.directory.cram_file())
         seqids = cram.seqids()
         input_json = InputJson(self.directory.input_json())
-        expected_seqids = input_json.bams()
+        expected_seqids = input_json.readgroups()
         if len(expected_seqids) != len(seqids):
             logger.error("Number of BAMs in JSON {0} doesn't match readgroups in CRAM {1}".format(len(expected_seqids), len(seqids)))
             return False


### PR DESCRIPTION
Occasionally see FASTQ as inputs instead of aligned or unaligned BAMs.
Handle this when checking that we see the correct number of readgroups.